### PR TITLE
[WAZO-4212] Remove channel lock checks

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+xivo-res-freeze-check (25.14~20250922) wazo-dev-bullseye; urgency=medium
+
+  * Remove channels lock check
+
+ -- Wazo Maintainers <dev+pkg@wazo.community>  Mon, 22 Sep 2025 09:38:29 -0400
+
 xivo-res-freeze-check (25.07~20250512) wazo-dev-bullseye; urgency=medium
 
   * Add queues lock check


### PR DESCRIPTION
Why: with the introduction of CHANNELSTORAGE_API in 22.5.0, locks
are exposed via this API and it requires a lot of work to do the
same checks as we did before. Given that we will switch to the
new channel backend soon, it does not make sense to migrate the
freeze checks when we will not need them with the new backend.
