### PR TITLE
[ITEM-361] asterisk-22.9.0: add new field to struct ast_app

### DIFF
--- a/res_freeze_check.c
+++ b/res_freeze_check.c
@@ -94,6 +94,7 @@ struct ast_app {
 	int (*execute)(struct ast_channel *chan, const char *data);
 	AST_DECLARE_STRING_FIELDS(
 		AST_STRING_FIELD(synopsis);     /*!< Synopsis text for 'show applications' */
+		AST_STRING_FIELD(provided_by);  /*!< Provided-by text for 'show applications' */
 		AST_STRING_FIELD(since);        /*!< Since text for 'show applications' */
 		AST_STRING_FIELD(description);  /*!< Description (help text) for 'show application &lt;name&gt;' */
 		AST_STRING_FIELD(syntax);       /*!< Syntax text for 'core show applications' */


### PR DESCRIPTION
Depends-On: https://github.com/wazo-platform/asterisk/pull/186

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized struct-layout alignment change with minimal behavioral impact; risk is mainly limited to potential runtime/ABI issues if the struct definition still diverges from the linked Asterisk version.
> 
> **Overview**
> `res_freeze_check.c` updates its locally-copied `struct ast_app` definition (used to access `pbx_findapp()` results) by adding the new `provided_by` string field in the `AST_DECLARE_STRING_FIELDS` block.
> 
> This is a compatibility/alignment change so the module’s private struct layout matches the updated upstream `ast_app` structure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c837953394e350e44e195c803fbb477862aab5e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->